### PR TITLE
Make 'a@' fail validation

### DIFF
--- a/lib/email-validation.js
+++ b/lib/email-validation.js
@@ -54,6 +54,7 @@ email.parse = function(address, dothrow, callback) {
         _domain += address[i];
       }
     }
+    if(_domain === '') throw util.format("[Error parseing email address: no domain part]", address);
     if(hostisip && !require('net').isIP(address.substring(hoststartpos+1,address.length-1))) throw util.format("[Error parsing email address: invalid IP address]");
     if(hostisip && address[address.length-1] != "]") throw util.format("[Error parsing email address: IP address notation must end with a ']']");
     if(!hostisip && (/^.+@([a-z0-9]{64,}(|\.))/i).test(address)) throw util.format("[Error parsing email address: hostname has elements greater than 63 characters]");

--- a/tests/test-addresses.js
+++ b/tests/test-addresses.js
@@ -16,6 +16,10 @@ assert.equal(parsebad, false);
 assert.equal(typeof parsebad['user'], 'undefined');
 assert.equal(typeof parsebad['domain'], 'undefined');
 
+parsebad = email.parse("a@");
+assert.equal(parsebad, false);
+assert.equal(typeof parsebad['user'], 'undefined');
+assert.equal(typeof parsebad['domain'], 'undefined');
 
 //good
 assert.ok(email.valid('email@example.com'));
@@ -31,6 +35,7 @@ assert.equal(email.valid('badip@[827.750.304.001'), false);
 assert.equal(email.valid('bad@ThisHostAddressSpaceIsGreaterThanSixtyThreeCharactersLetsSeeHowManyICanFitInHereWithoutDestroyingTheWorld.com'), false);
 assert.equal(email.valid('bad@ThisAddressIsGreaterThanTwoHundredAndFiftyThreeCharactersLetsSeeHowManyICanFitInHereWithoutDestroyingTheWorld.com.Unfortunatly.we.were.not.quite.there.yet.but.we.getting.closer.by.the.minute.I.assure.you.we.are.almost.there.dot.some.new.top.level.domain.com.us.tz.kosher'), false);
 assert.equal(email.valid('one.two@-one-two.com'), false);
+assert.equal(email.valid('a@'), false);
 
 //shamelessly copied from http://en.wikipedia.org/wiki/Email_address
 assert.ok(email.valid('niceandsimple@example.com'));


### PR DESCRIPTION
First commit adds tests for 'a@', which fail against current HEAD.

Second commit adds a check for an empty `_domain` and throws an exception if found. 

All other tests continue to pass and the speed test doesn't show any detectable difference. 